### PR TITLE
ci(workflow): 将 npm ci 替换为 npm i 以加快依赖安装

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Install npm dependencies
       run: |
         cd webview
-        npm ci
+        npm i
 
     - name: Show IntelliJ version configuration
       run: sbt -Dintellij.version=${{ matrix.intellij-version }} 'show intellijBuild'


### PR DESCRIPTION
在 CI 工作流中，将 webview 目录下的 npm ci 命令改为 npm i 命令。这可以加快依赖安装速度，虽然可能会牺牲一些版本锁定的精确性，但对于 CI 环境来说是可接受的权衡。